### PR TITLE
Update context.md for timezone configuration explanation

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -40,6 +40,33 @@ To get device-local date and time, the following shorthand methods are available
 - `Context.today()`: returns the current device-local date (current day at midnight)
 
 Both methods return `datetime.datetime` value with `datetime.tzinfo`
+
+The timezone must be provided by as an attribute to the intent, which can be automated in the intent configuration like this:
+
+**Example**
+
+CVI configuration for minimum MYINTENT intent getting timezone of the device as a parameter.
+
+```json
+    {
+      "name": "MYINTENT",
+      "entityFiller": "",
+      "entities": [
+        {
+          "name": "timezone",
+          "type": "TIMEZONE",
+          "fillPolicy": [
+            "device"
+          ],
+          "useFromSession": true
+        }
+      ],
+      "prompts": [],
+      "requiredTokens": [],
+      "errors": []
+    }
+```
+
  
 ## Detailed information about specific attributes
 


### PR DESCRIPTION
Explanation, that the context.now and context.today only work properly if the intent is configured to receive the timezone as a parameter.