### PR TITLE
Feature/bump spi version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [v0.11.0] - 2021-02-18  
+
+**Bugfixes**
+
+-   Session size limit check has been removed.
+
+**Miscellaneous**
+
+-   Skill SPI has been bumped to version 1.3. 
+-   Requirements bump:
+    - apispec from 4.2.0 to 4.3.0 
+
 ## [v0.10.5] - 2021-02-10  
 
 **Features**

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ python-dateutil==2.8.1    # [dateutil - powerful extensions to datetime](https:/
 pyyaml==5.4.1             # [PyYAML is a YAML parser and emitter for Python.](https://pyyaml.org/)
 requests==2.25.1          # [Python HTTP Requests for Humans](http://python-requests.org)
 timezonefinder==5.2.0     # [a lightweight python library for finding the timezone of any point on earth (coordinates), but fast!](https://github.com/MrMinimal64/timezonefinder)
-apispec==4.2.0            # [A pluggable API specification generator](https://apispec.readthedocs.io/en/stable/)
+apispec==4.3.0            # [A pluggable API specification generator](https://apispec.readthedocs.io/en/stable/)
 py-zipkin==0.20.1         # [Provides utilities to facilitate the usage of Zipkin in Python](https://github.com/Yelp/py_zipkin)

--- a/skill_sdk/__version__.py
+++ b/skill_sdk/__version__.py
@@ -22,10 +22,10 @@
 __name__ = 'skill-sdk'
 __description__ = 'Magenta Voice Skill SDK for Python'
 __url__ = 'https://github.com/telekom/voice-skill-sdk/'
-__version__ = '0.10.5'
+__version__ = '0.11.0'
 __author__ = 'Deutsche Telekom Voicification Suite'
 __author_email__ = 'vineet.hingorani@telekom.de'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2020, Deutsche Telekom AG'
 
-__spi_version__ = '1.2'
+__spi_version__ = '1.3'

--- a/skill_sdk/intents.py
+++ b/skill_sdk/intents.py
@@ -79,7 +79,9 @@ class Context:
         request_data = request.json
         request_context = request_data.get('context')
         self.intent_name = request_context.get('intent')
-        self.spi_version = request_data.get('spiVersion')
+        self.spi_version = request_context.get('spiVersion')
+        self.client_type_name = request_context.get('clientTypeName')
+        self.user_profile_config = request_context.get('userProfileConfig')
         self.locale = {'language': request_context.get('locale')}
         logger.debug('Language: %s', self.locale)
         self.translation = get_translation(self.locale['language'])
@@ -132,6 +134,8 @@ class Context:
             session=self.session,
             configuration=self.configuration,
             attributesV2=self.attributesV2,
+            clientTypeName=self.client_type_name,
+            userProfileConfig=self.user_profile_config,
             spi_version=self.spi_version,
         )
 

--- a/skill_sdk/sessions.py
+++ b/skill_sdk/sessions.py
@@ -14,36 +14,29 @@
 import logging
 
 
-MAX_SESSION_STORAGE_SIZE = 4096
-
 logger = logging.getLogger(__name__)
 
 
-class SessionOversizeError(Exception):
-    '''
-    an exception raised when the current action would increase the size of the session over
-    :py:const:`MAX_SESSION_STORAGE_SIZE` bytes.
-    '''
-
-
 class SessionInvalidKeyError(Exception):
-    '''
+    """
     This exception will be raised if a session key is an empty string.
-    '''
+    """
 
 
 class Session(dict):
-    '''
+    """
     A session object that will persist between different of the intent that belong to one session.
 
     The session acts like a dictionary with a few limitation:
 
     * keys and values must by string, if they are not they are casted
     * keys must not be an empty string
-    * the sum of all lengths of all keys and values must not exceed :py:const:`MAX_SESSION_STORAGE_SIZE`.
 
-    The session is accessible as ``context.session`` in the intent handler.
-    '''
+    * v0.11.0 REMOVED: the sum of all lengths of all keys and values must not exceed
+        :py:const:`MAX_SESSION_STORAGE_SIZE`.
+
+    The session is accessible as `context.session` in the intent handler.
+    """
 
     def __init__(self, session_id, new_session, *args, **kwargs):
         self.session_id = session_id
@@ -51,21 +44,21 @@ class Session(dict):
         super().__init__(*args, **kwargs)
 
     def get_storage_size(self):
-        '''
+        """
         Calculates the storage size of the session.
-        '''
+        """
         size = sum(len(k) + len(v) for (k, v) in self.items())
-        logger.debug('Size of session %s is now %s', self.session_id, size)
+        logger.debug("Size of session %s is now %s", self.session_id, size)
         return size
 
     def update(self, e=None, **kwargs):
-        '''
+        """
         Replacement of the original update method to enforce the size limit by calling the overwritten
         :py:method:`__setitem__`.
 
         :param e: a dictionary with key/value pair to update with
         :param **kwargs: new key/value pairs can also be
-        '''
+        """
         if e:
             for key, value in e.items():
                 self[key] = value
@@ -73,17 +66,14 @@ class Session(dict):
             self[key] = value
 
     def __setitem__(self, key, value):
-        '''
-        Overwrites the original ``__setattr__` to enforce the limitations.
-        '''
+        """
+        Overwrites the original `__setitem__` to perform validation.
+        """
         key = key if isinstance(key, str) else str(key)
         value = value if isinstance(value, str) else str(value)
         if not key:
-            raise SessionInvalidKeyError('Session key can not be empty strings')
-        old_value = self.get(key)
+            raise SessionInvalidKeyError("Session key can not be empty strings")
+
+        # Log session size
+        self.get_storage_size()
         dict.__setitem__(self, key, value)
-        if self.get_storage_size() > MAX_SESSION_STORAGE_SIZE:
-            if old_value is not None:
-                self.__setitem__(key, old_value)
-            raise SessionOversizeError('Storing the value "{}" into "{}" will exceed the max. session size of {}.'
-                                       .format(value, key, MAX_SESSION_STORAGE_SIZE))

--- a/skill_sdk/test_helpers.py
+++ b/skill_sdk/test_helpers.py
@@ -143,7 +143,10 @@ def create_context(intent: str,
             "locale": locale or "de",
             "attributes": attributes or {},
             "attributesV2": attributes_v2 or {},
-            "configuration": configuration or {}
+            "configuration": configuration or {},
+            "spiVersion": __spi_version__,
+            "clientTypeName": kwargs.get("client_type_name", "DEFAULT"),
+            "userProfileConfig": kwargs.get("user_profile_config", "DEFAULT"),
         },
         "session": _session,
     }

--- a/tests/intents_context_test.py
+++ b/tests/intents_context_test.py
@@ -12,13 +12,13 @@ import time
 import logging
 import datetime
 import unittest
-import importlib
 from unittest.mock import patch
 from types import SimpleNamespace
 from gettext import NullTranslations
 from dateutil import tz
 
 from skill_sdk import l10n
+from skill_sdk.__version__ import __spi_version__
 from skill_sdk.intents import Context
 from skill_sdk.test_helpers import create_context, mock_datetime_now
 
@@ -43,8 +43,10 @@ class TestIntentsContext(unittest.TestCase):
         self.assertEqual(self.ctx.locale, {'language': 'de'})
         self.assertEqual(self.ctx.session.new_session, True)
         self.assertEqual(self.ctx.session.session_id, '12345')
-        self.assertEqual(self.ctx.configuration, {'a': ['123'],
-                                              'b': [1, 2, 3]})
+        self.assertEqual(self.ctx.configuration, {'a': ['123'], 'b': [1, 2, 3]})
+        self.assertEqual(self.ctx.spi_version, __spi_version__)
+        self.assertEqual(self.ctx.client_type_name, "DEFAULT")
+        self.assertEqual(self.ctx.user_profile_config, "DEFAULT")
 
     def test_no_translations(self):
         from unittest import mock

--- a/tests/session_test.py
+++ b/tests/session_test.py
@@ -9,7 +9,7 @@
 #
 import unittest
 
-from skill_sdk.sessions import Session, SessionOversizeError, SessionInvalidKeyError
+from skill_sdk.sessions import Session, SessionInvalidKeyError
 
 
 class TestSession(unittest.TestCase):
@@ -51,22 +51,6 @@ class TestSession(unittest.TestCase):
         with self.assertRaises(SessionInvalidKeyError):
             self.s[''] = '1'
 
-    def test_setitem_oversize_empty_long_key(self):
-        with self.assertRaises(SessionOversizeError):
-            self.s[5000 * 'a'] = '1'
-
-    def test_setitem_oversize_empty_long_value(self):
-        with self.assertRaises(SessionOversizeError):
-            self.s['abc'] = 5000 * 'a'
-
-    def test_restore_old_value_on_oversize_error(self):
-        self.s['abc'] = '123'
-        try:
-            self.s['abc'] = 5000 * 'a'
-        except SessionOversizeError:
-            pass
-        self.assertEqual(self.s['abc'], '123')
-
     def test_update(self):
         self.s.update({'a': 'b'})
         self.assertEqual(self.s['a'], 'b')
@@ -89,11 +73,3 @@ class TestSession(unittest.TestCase):
         self.s['a'] = '1'
         self.s.update({'a': 'a'}, a='b')
         self.assertEqual(self.s['a'], 'b')
-
-    def test_oversize_on_update(self):
-        with self.assertRaises(SessionOversizeError):
-            self.s.update({5000 * 'a': '1'})
-
-    def test_oversize_on_update_kwargs(self):
-        with self.assertRaises(SessionOversizeError):
-            self.s.update(abc=5000 * '1')


### PR DESCRIPTION
Skill SPI has been bumped to version 1.3:
  - Client type name added to skill invoke context
  - User profile config (VPC name) added to context
  
BUGFIX: session size limit check has been removed