### PR TITLE
Add response_hook parameter to CircuitBreakerSession

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ circuitbreaker==1.3.1     # [Python "Circuit Breaker" implementation](https://gi
 gevent==21.1.2            # [Coroutine-based concurrency library for Python](http://gevent.org)
 gunicorn==20.0.4          # ['Green Unicorn' is a WSGI HTTP Server for UNIX, fast clients and sleepy applications.](http://www.gunicorn.org)
 isodate==0.6.0            # [ISO 8601 date/time parser](https://github.com/gweis/isodate/)
-prometheus_client==0.9.0  # [Prometheus instrumentation library for Python applications](https://github.com/prometheus/client_python)
+prometheus_client==0.10.0  # [Prometheus instrumentation library for Python applications](https://github.com/prometheus/client_python)
 opentracing==2.4.0        # [Python platform API for OpenTracing](https://opentracing.io/)
 python-dateutil==2.8.1    # [dateutil - powerful extensions to datetime](https://dateutil.readthedocs.io/en/stable/index.html)
 pyyaml==5.4.1             # [PyYAML is a YAML parser and emitter for Python.](https://pyyaml.org/)

--- a/skill_sdk/services/prometheus.py
+++ b/skill_sdk/services/prometheus.py
@@ -43,7 +43,7 @@ http_partner_request_count_total = Counter('http_partner_request_count', 'HTTP R
 
 
 def update_stats():
-    """ Update current mertics """
+    """Update current metrics"""
     intent_gauge.set(len(app().get_intents()))
     thread_count.set(active_count())
     open_circuit_breakers.set(sum(1 for _ in CircuitBreakerMonitor.get_open()))
@@ -51,10 +51,11 @@ def update_stats():
 
 @contextmanager
 def partner_call(callback, partner_name: str):
-    """ Context manager to count HTTP requests to partner services
-            ...
-            with partner_call(session.get, 'partner-service-name') as get:
-                response = get(URL)
+    """
+    Context manager to count HTTP requests to partner services
+
+        >>> with partner_call(requests.get, 'partner-service-name') as get:
+        >>>     response = get(URL)
 
     """
     def wrapper(*args, **kwargs):   # NOSONAR
@@ -66,8 +67,24 @@ def partner_call(callback, partner_name: str):
     yield wrapper
 
 
+def count_partner_calls(partner_name: str):
+    """
+    Hook that can be attached to `requests.session` to count HTTP requests to partner services:
+
+        >>> with CircuitBreakerSession(response_hook=count_partner_calls('partner-service-name')) as session:
+        >>>     session.get(URL)
+
+    @param partner_name:
+    @return:
+    """
+    return lambda r, **kwargs: http_partner_request_count_total.labels(
+        job=config.get('skill', 'name'),
+        partner_name=partner_name,
+        status=r.status_code).inc()
+
+
 def prometheus(callback):
-    """ In-progress requests counter """
+    """In-progress requests counter"""
 
     @in_progress_requests.track_inprogress()
     def wrapper(*args, **kwargs):   # NOSONAR
@@ -85,13 +102,13 @@ def prometheus(callback):
 
 
 class PrometheusLatency:
-    """ Prometheus latency  wrapper. Can be used as decorator:
-            ...
+    """
+    Prometheus latency  wrapper. Can be used as decorator:
 
-        # As decorator:
-        @prometheus_latency('operation_name')
-        def decorated():
-            ...
+        >>> # As decorator:
+        >>> @prometheus_latency('operation_name')
+        >>> def decorated():
+        >>>     ...
 
     """
 
@@ -115,7 +132,8 @@ prometheus_latency = PrometheusLatency
 
 @get('/prometheus')
 def metrics():
-    """ Prometheus metrics endpoint.
+    """
+    Prometheus metrics endpoint.
     ---
     get:
         description: Get Prometheus metrics
@@ -133,7 +151,7 @@ def metrics():
 
 
 def setup_service():
-    """ Setup prometheus client """
+    """Setup prometheus client"""
 
     # Initialize multiprocessing mode
     workers = config.getint('http', 'workers', fallback=1)

--- a/skill_sdk/services/prometheus.py
+++ b/skill_sdk/services/prometheus.py
@@ -77,10 +77,20 @@ def count_partner_calls(partner_name: str):
     @param partner_name:
     @return:
     """
-    return lambda r, **kwargs: http_partner_request_count_total.labels(
-        job=config.get('skill', 'name'),
-        partner_name=partner_name,
-        status=r.status_code).inc()
+    def hook(r, **kwargs):
+        """
+        This hook is executed after response is received
+
+        @param r:       HTTP response
+        @param kwargs:  keyword arguments used to construct the request (headers, cookies, timeout, etc.)
+        @return:        not supposed to return anything
+        """
+        http_partner_request_count_total.labels(
+            job=config.get('skill', 'name'),
+            partner_name=partner_name,
+            status=r.status_code).inc()
+
+    return hook
 
 
 def prometheus(callback):


### PR DESCRIPTION
This PR adds response_hook parameter to `CircuitBreakerSession` constructor. It allows attaching `count_partner_calls` hook to collect error requests count that otherwise would be skipped:

```
from skill_sdk.requests import CircuitBreakerSession
from skill_sdk.services.prometheus import count_partner_calls

with CircuitBreakerSession(response_hook=count_partner_calls('partner-service-name')) as session:
    session.get(URL)
``` 
