### PR TITLE
Fix error when returning an instance of Reprompt from an intent handler

### DIFF
--- a/skill_sdk/responses/reprompt.py
+++ b/skill_sdk/responses/reprompt.py
@@ -46,14 +46,16 @@ class Reprompt(SkillInvokeResponse):
         name = f"{request.context.intent}{'_' + entity if entity else ''}_reprompt_count"
 
         try:
-            request.session.attributes[name] = int(request.session.attributes.get(name, 0)) + 1
-        except ValueError:
-            request.session.attributes[name] = 1
+            reprompt_count = int(request.session.attributes[name]) + 1
+        except (KeyError, ValueError):
+            reprompt_count = 1
 
-        if request.session.attributes[name] > max_reprompts > 0:
+        if reprompt_count > max_reprompts > 0:
             del request.session.attributes[name]
             values['text'] = values['stop_text']
             values['type'] = ResponseType.TELL
+        else:
+            request.session.attributes[name] = reprompt_count
 
         return max_reprompts
 

--- a/skill_sdk/responses/reprompt.py
+++ b/skill_sdk/responses/reprompt.py
@@ -11,6 +11,7 @@
 """Re-prompt response"""
 
 from typing import Optional, Text
+from pydantic import validator
 
 from skill_sdk.intents import request
 
@@ -32,11 +33,29 @@ class Reprompt(SkillInvokeResponse):
     # stop text will be sent if number of re-prompts is higher than maximum number
     stop_text: Optional[Text]
 
+    # entity name if re-prompt is used for intent/entity
+    entity: Optional[Text]
+
     # maximum number of re-prompts
     max_reprompts: int
 
-    # entity name if re-prompt is used for intent/entity
-    entity: Optional[Text]
+    @validator('max_reprompts')
+    def check_max_reprompts(cls, max_reprompts, values):
+        # Name of the counter formatted as INTENT_ENTITY_reprompt_count
+        entity = values.get('entity')
+        name = f"{request.context.intent}{'_' + entity if entity else ''}_reprompt_count"
+
+        try:
+            request.session.attributes[name] = int(request.session.attributes.get(name, 0)) + 1
+        except ValueError:
+            request.session.attributes[name] = 1
+
+        if request.session.attributes[name] > max_reprompts > 0:
+            del request.session.attributes[name]
+            values['text'] = values['stop_text']
+            values['type'] = ResponseType.TELL
+
+        return max_reprompts
 
     def __init__(
         self,
@@ -53,27 +72,3 @@ class Reprompt(SkillInvokeResponse):
             entity=entity,
             **kwargs,
         )
-
-    def dict(self):
-        """
-        Get/set the number of re-prompts in session
-        """
-
-        # Name of the counter formatted as INTENT_ENTITY_reprompt_count
-        name = f"{request.context.intent}{'_' + self.entity if self.entity else ''}_reprompt_count"
-
-        try:
-            reprompt_count = int(request.session[name]) + 1
-        except (KeyError, ValueError):
-            reprompt_count = 1
-
-        if reprompt_count > self.max_reprompts > 0:
-            del request.session[name]
-            response = self.copy(
-                update=dict(text=self.stop_text, type=ResponseType.TELL)
-            )
-        else:
-            request.session[name] = reprompt_count
-            response = super()
-
-        return response.dict()

--- a/tests/responses/test_reprompt.py
+++ b/tests/responses/test_reprompt.py
@@ -17,21 +17,22 @@ def test_reprompt_response(monkeypatch):
     from skill_sdk.utils.util import test_request
 
     with test_request("SMALLTALK__GREETINGS"):
-        assert isinstance(Reprompt("abc123"), Response)
+        response = Reprompt("abc123")
+        assert isinstance(response, Response)
 
-        response = Reprompt("abc123").dict()
-        assert response["text"] == "abc123"
-        assert response["type"] == ResponseType.ASK
+        response_dict = response.dict()
+        assert response_dict["text"] == "abc123"
+        assert response_dict["type"] == ResponseType.ASK
         assert request.session["SMALLTALK__GREETINGS_reprompt_count"] == 1
 
-        response = Reprompt("abc123").dict()
-        assert response["text"] == "abc123"
-        assert response["type"] == ResponseType.ASK
+        response_dict = Reprompt("abc123").dict()
+        assert response_dict["text"] == "abc123"
+        assert response_dict["type"] == ResponseType.ASK
         assert request.session["SMALLTALK__GREETINGS_reprompt_count"] == 2
 
-        response = Reprompt("abc123", "321cba", 2).dict()
-        assert response["text"] == "321cba"
-        assert response["type"] == ResponseType.TELL
+        response_dict = Reprompt("abc123", "321cba", 2).dict()
+        assert response_dict["text"] == "321cba"
+        assert response_dict["type"] == ResponseType.TELL
         assert "SMALLTALK_GREETINGS_reprompt_count" not in request.session
 
         monkeypatch.setitem(


### PR DESCRIPTION
This error is also mentioned here: https://jira.telekom.de/browse/HMCN-667

In skill-sdk 1.1.6, returning an instance of `Reprompt` from an intent handler results in the following error message:
```
{"@timestamp": 1646041312140, "level": "ERROR", "process": 13476, "thread": "13404", "logger": "skill_sdk.intents.request", "message": "Accessing request local object outside of the request-response cycle.", "traceId": null, "spanId": null, "testing": false, "tenant": null, "magentaTransactionId": null}
```

This is fixed by moving the reprompt count checking logic from `Response.dict()` to a pydantic validator.

As a side-effect, the `TELL` response created when max reprompt count is exceeded was changed.
It now also contains `Reprompt`-specific keys such as `stopText` and `maxReprompts`, but this shouldn't be a problem for existing code.