### PR TITLE
Enhance User-Agent header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Features
+
+- Enhance User-Agent header to include kubernetes POD name when it comes to SVH cluster requests
+
 ## 1.1.9 - 2022-03-31
 
 ### Bugfixes

--- a/skill_sdk/services/base.py
+++ b/skill_sdk/services/base.py
@@ -11,6 +11,7 @@
 """Base for internal services"""
 
 import logging
+from os import environ
 from typing import Dict, Text
 
 from aiobreaker import CircuitBreaker
@@ -101,6 +102,11 @@ class BaseService:
             "Accept": "application/json",
             "Content-Type": "application/json",
         }
+
+        # 'HOSTNAME' is the environment value provided by k8s (actually the pod name)
+        user_agent = environ.get("HOSTNAME") or None
+        if user_agent is not None:
+            _headers.update({"User-Agent": user_agent})
 
         # If inside a request, add "Content-Language"
         if r and r.context:


### PR DESCRIPTION
Enhance User-Agent header to include Kubernetes POD name when it comes to SVH cluster requests